### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Atlas.Mixfile do
       package: [
         contributors: ["Chris McCord", "Sonny Scroggin"],
         licenses: ["MIT"],
-        links: [github: "https://github.com/chrismccord/atlas"]
+        links: %{"GitHub" => "https://github.com/chrismccord/atlas"}
       ],
       description: """
       Object Relational Mapper for Elixir


### PR DESCRIPTION
Changing links section of `mix.exs` because links is supposed to be a map now.
